### PR TITLE
Add a check for prog_id to fix bad last of the day/first of the day merges

### DIFF
--- a/tvgrabpyAPI/tv_grab_fetch.py
+++ b/tvgrabpyAPI/tv_grab_fetch.py
@@ -2882,6 +2882,7 @@ class FetchData(URLtypes, Thread):
                         if 'last of the page' in p.keys():
                             # Check for a program split by the day border
                             if p[ 'name'].lower() == p2[ 'name'].lower() and p['stop-time'] >= p2['start-time'] \
+                              and p['prog_ID'] == p2['prog_ID'] \
                               and ((not 'episode title' in p and not 'episode title' in p2) \
                                 or ('episode title' in p and 'episode title' in p2 \
                                 and p[ 'episode title'].lower() == p2[ 'episode title'].lower())):


### PR DESCRIPTION
If the prog_id is unique, it means it's a seperate episode and shouldn't be merged

I came across this issue when testing the new tvgids.tv/gids.tv replacement source since episode titles are not available from the base pages, so it incorectly merged a bunch of 05:30 and 06:00 shows into an hour long 05:30-06:30 block.